### PR TITLE
Mongo user on sign up

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,9 +12,9 @@ import Events from './components/pages/events';
 import LogHours from './components/pages/logHours';
 import CreateEvent from './components/pages/createEvent';
 import VolunteerLog from './components/pages/volunteerLog';
-import awsconfig from './aws-exports';
+// import awsconfig from './aws-exports';
 
-Amplify.configure(awsconfig);
+// Amplify.configure(awsconfig);
 Amplify.configure({
   Auth: {
     // Amazon Cognito Region

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -47,7 +47,15 @@ interface Shift {
 
 function App() {
   const [events, setEvents] = useState<Event[]>([]);
+  // 'setUser' sets the 'currentUser' to the
+  // mongodb user document fetched on login,
+  // doc includes the users userSub
+  const [currentUser, setUser] = useState('');
+  const [pastShifts, setPastShifts] = useState<Shift[]>([]);
 
+  const user = 'sam';
+
+  // loads in all events
   useEffect(() => {
     const loadEvents = async () => {
       await fetch('http://localhost:3001/events')
@@ -62,17 +70,7 @@ function App() {
     loadEvents();
   }, []);
 
-  // 'setUser' sets the 'currentUser' to the
-  // mongodb user document fetched on login,
-  // doc includes the users userSub
-  /* eslint-disable */
-  const [currentUser, setUser] = useState('');
-  const [pastShifts, setPastShifts] = useState<Shift[]>([]);
-
-  const user = 'sam';
-
-  console.log(currentUser);
-
+  // get user's past shifts from db
   useEffect(() => {
     const loadPastShifts = async () => {
       await fetch(`http://localhost:3001/users/${user}`)
@@ -86,19 +84,10 @@ function App() {
     loadPastShifts();
   }, []);
 
+  // runs when currentUser is updated
   useEffect(() => {
-    const loadEvents = async () => {
-      await fetch('http://localhost:3001/events')
-        .then((res) => res.json())
-        .then((data) => {
-          setEvents(data);
-          // console.log(data);
-        })
-        .catch((err) => console.log(err));
-    };
-
-    loadEvents();
-  }, []);
+    console.log('currentUser has been updated: ', currentUser);
+  }, [currentUser]);
 
   return (
     <div className="App">

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -62,8 +62,9 @@ function App() {
     loadEvents();
   }, []);
 
-  // 'setUser' sets the 'currentUser' to the 'userSub' value,
-  // which is a unique identifier
+  // 'setUser' sets the 'currentUser' to the
+  // mongodb user document fetched on login,
+  // doc includes the users userSub
   /* eslint-disable */
   const [currentUser, setUser] = useState('');
   const [pastShifts, setPastShifts] = useState<Shift[]>([]);

--- a/frontend/src/components/authentication/createAccount.tsx
+++ b/frontend/src/components/authentication/createAccount.tsx
@@ -78,6 +78,7 @@ export default function CreateAccount() {
       }
     } catch (error) {
       console.log('error signing up:', error);
+      window.alert(error);
     }
   };
 

--- a/frontend/src/components/authentication/login.tsx
+++ b/frontend/src/components/authentication/login.tsx
@@ -87,11 +87,28 @@ export default function LoginPage({
     console.log(password);
   };
 
+  // fetches user who signed in here
+  const getMongoUser = async (id: string) => {
+    try {
+      fetch(`http://localhost:3001/users/${id}`)
+        .then((res) => res.json())
+        .then((data) => {
+          setUser(data);
+        })
+        .catch((err) => console.log(err));
+    } catch (error) {
+      console.log('error getting user from mongodb', error);
+    }
+  };
+
   // authenticate sign in
   const signIn = async () => {
     try {
       const user = await Auth.signIn(username, password);
-      setUser(user.userSub);
+      console.log(user);
+      // note: the user id is stored in the username
+      // attribute of object returned by signIn
+      await getMongoUser(user.username);
       console.log(`Successful sign in for user: ${username}`);
     } catch (error) {
       console.log('error signing in', error);

--- a/frontend/src/components/authentication/login.tsx
+++ b/frontend/src/components/authentication/login.tsx
@@ -87,7 +87,7 @@ export default function LoginPage({
     console.log(password);
   };
 
-  // fetches user who signed in here
+  // fetches Mongo user who signed in
   const getMongoUser = async (id: string) => {
     try {
       fetch(`http://localhost:3001/users/${id}`)
@@ -104,14 +104,18 @@ export default function LoginPage({
   // authenticate sign in
   const signIn = async () => {
     try {
+      // first get cognitoUser
       const user = await Auth.signIn(username, password);
       console.log(user);
       // note: the user id is stored in the username
       // attribute of object returned by signIn
+
+      // then get mongoUser
       await getMongoUser(user.username);
       console.log(`Successful sign in for user: ${username}`);
     } catch (error) {
       console.log('error signing in', error);
+      window.alert(error);
     }
   };
 


### PR DESCRIPTION
When a user signs up a document corresponding to that user is posted to the mongo db database. In mongo, user document's id's are the same as their AWS userSub.

When logging in, users are fetched from the db after confirmed with cognito. I used the setUser state function to set the user as the _whole_ user doc fetched rather than just the _Id/userSub. I figured this makes more sense so we only have to make API calls to post data rater than call all over the place with just the userid. If you would rather I just set it to the _id in setUser I can change that back.
Let me know if any fixes are needed!

closes #68 