### PR TITLE
Admin edit prizes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import CreateEvent from './components/pages/createEvent';
 import VolunteerLog from './components/pages/volunteerLog';
 import EditProgressBar from './components/pages/editProgressBar';
 import EditPrizes from './components/pages/editPrizes';
+import EditOnePrize from './components/pages/editOnePrize';
 import userContext from './userContext';
 import { Event, Shift, User } from './types';
 // import awsconfig from './aws-exports';
@@ -184,6 +185,14 @@ function App() {
               element={
                 <ProtectedRoute setUser={setUser}>
                   <EditProgressBar />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/edit-prizes/:prizeId"
+              element={
+                <ProtectedRoute setUser={setUser}>
+                  <EditOnePrize />
                 </ProtectedRoute>
               }
             />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,7 @@ import EditProgressBar from './components/pages/editProgressBar';
 import EditPrizes from './components/pages/editPrizes';
 import EditOnePrize from './components/pages/editOnePrize';
 import userContext from './userContext';
-import { Event, Shift, User } from './types';
+import { Event, Shift, User, Prize } from './types';
 // import awsconfig from './aws-exports';
 
 // Amplify.configure(awsconfig);
@@ -43,6 +43,7 @@ function App() {
   const [currentUser, setUser] = useState<User>({} as User);
   const [pastShifts, setPastShifts] = useState<Shift[]>([]);
   const [allShifts, setAllShifts] = useState<Shift[]>([]);
+  const [prizes, setPrizes] = useState<Prize[]>([]);
   const [userInfo, setUserInfo] = useState<User | undefined>(undefined);
 
   // loads in all events
@@ -93,32 +94,26 @@ function App() {
     }
   }, [userInfo]);
 
+  // get prizes from db
+  useEffect(() => {
+    const loadPrizes = async () => {
+      await fetch(`http://localhost:3001/prizes`)
+        .then((res) => res.json())
+        .then((data) => {
+          setPrizes(data);
+        })
+        .catch((err) => console.log(err));
+    };
+
+    if (userInfo?.isAdmin) {
+      loadPrizes();
+    }
+  }, [userInfo]);
+
   // runs when currentUser is updated
   useEffect(() => {
     console.log('currentUser has been updated: ', currentUser);
   }, [currentUser]);
-
-  // dummy data for edit prizes
-  // I built in the props and everything so
-  // backend people don't have to deal with it :)
-  const prizeData = [
-    {
-      _id: 'aa8dsada9dah',
-      itemName: '$400 gift card',
-      sponsorName: 'jeff',
-      sponsorImage:
-        'https://m.media-amazon.com/images/I/61OdJeN2lFL._SY445_.jpg',
-      hoursNeeded: 1,
-    },
-    {
-      _id: 'aa8dsada9daasdadsh',
-      itemName: 'chicken nuggs',
-      sponsorName: 'McDonalds (TM)',
-      sponsorImage:
-        'https://upload.wikimedia.org/wikipedia/commons/thumb/6/64/Chicken_Nuggets.jpg/640px-Chicken_Nuggets.jpg',
-      hoursNeeded: 400,
-    },
-  ];
 
   // TODO: value={currentUser} when we get auth finalized
   return (
@@ -202,7 +197,7 @@ function App() {
               path="/edit-prizes"
               element={
                 <ProtectedRoute setUser={setUser}>
-                  <EditPrizes prizeData={prizeData} />
+                  <EditPrizes prizeData={prizes} />
                 </ProtectedRoute>
               }
             />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import ThankYou from './components/pages/thankYou';
 import CreateEvent from './components/pages/createEvent';
 import VolunteerLog from './components/pages/volunteerLog';
 import EditProgressBar from './components/pages/editProgressBar';
+import EditPrizes from './components/pages/editPrizes';
 import userContext from './userContext';
 import { Event, Shift, User } from './types';
 // import awsconfig from './aws-exports';
@@ -96,6 +97,26 @@ function App() {
     console.log('currentUser has been updated: ', currentUser);
   }, [currentUser]);
 
+  // dummy data for edit prizes
+  // I built in the props and everything so
+  // backend people don't have to deal with it :)
+  const prizeData = [
+    {
+      _id: 'aa8dsada9dah',
+      itemName: '$400 gift card',
+      sponsorName: 'jeff',
+      sponsorImage: 'jeff img',
+      hoursNeeded: 1,
+    },
+    {
+      _id: 'aa8dsada9daasdadsh',
+      itemName: 'chicken nuggs',
+      sponsorName: 'vgs',
+      sponsorImage: 'vgs img',
+      hoursNeeded: 400,
+    },
+  ];
+
   // TODO: value={currentUser} when we get auth finalized
   return (
     <userContext.Provider value={currentUser}>
@@ -163,6 +184,14 @@ function App() {
               element={
                 <ProtectedRoute setUser={setUser}>
                   <EditProgressBar />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/edit-prizes"
+              element={
+                <ProtectedRoute setUser={setUser}>
+                  <EditPrizes prizeData={prizeData} />
                 </ProtectedRoute>
               }
             />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -106,14 +106,16 @@ function App() {
       _id: 'aa8dsada9dah',
       itemName: '$400 gift card',
       sponsorName: 'jeff',
-      sponsorImage: 'jeff img',
+      sponsorImage:
+        'https://m.media-amazon.com/images/I/61OdJeN2lFL._SY445_.jpg',
       hoursNeeded: 1,
     },
     {
       _id: 'aa8dsada9daasdadsh',
       itemName: 'chicken nuggs',
-      sponsorName: 'vgs',
-      sponsorImage: 'vgs img',
+      sponsorName: 'McDonalds (TM)',
+      sponsorImage:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/6/64/Chicken_Nuggets.jpg/640px-Chicken_Nuggets.jpg',
       hoursNeeded: 400,
     },
   ];

--- a/frontend/src/components/navigation/navBar.tsx
+++ b/frontend/src/components/navigation/navBar.tsx
@@ -14,6 +14,7 @@ import {
   Label,
   StyledLink,
   LogoImage,
+  EditPrizeIcon,
 } from './navComponents';
 import logo from '../../imgs/logo.png';
 import userContext from '../../userContext';
@@ -57,6 +58,12 @@ export default function NavBar({ children }: Props) {
                 <Path active={!!useMatch('/progress-bar')}>
                   <ClipboardIcon />
                   <Label>Progress bar</Label>
+                </Path>
+              </StyledLink>
+              <StyledLink to="/edit-prizes">
+                <Path active={!!useMatch('/edit-prizes')}>
+                  <EditPrizeIcon />
+                  <Label>Edit Prizes</Label>
                 </Path>
               </StyledLink>
             </div>

--- a/frontend/src/components/navigation/navBar.tsx
+++ b/frontend/src/components/navigation/navBar.tsx
@@ -54,12 +54,6 @@ export default function NavBar({ children }: Props) {
                   <Label>Volunteer log</Label>
                 </Path>
               </StyledLink>
-              <StyledLink to="/progress-bar">
-                <Path active={!!useMatch('/progress-bar')}>
-                  <ClipboardIcon />
-                  <Label>Progress bar</Label>
-                </Path>
-              </StyledLink>
               <StyledLink to="/edit-prizes">
                 <Path active={!!useMatch('/edit-prizes')}>
                   <EditPrizeIcon />

--- a/frontend/src/components/navigation/navComponents.tsx
+++ b/frontend/src/components/navigation/navComponents.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
-import { FaBars, FaRegEdit } from 'react-icons/fa';
+import { BiEdit } from 'react-icons/bi';
+import { FaBars } from 'react-icons/fa';
 import { HiOutlineClipboardList } from 'react-icons/hi';
 import { GiBackwardTime } from 'react-icons/gi';
 import { MdLogout } from 'react-icons/md';
@@ -40,6 +41,14 @@ const AddIcon = styled(IoMdAddCircleOutline)`
 `;
 
 const CalendarIcon = styled(FiCalendar)`
+  color: white;
+  text-align: left;
+  display: block;
+  font-size: 50px;
+  display: inline-block;
+`;
+
+const EditPrizeIcon = styled(BiEdit)`
   color: white;
   text-align: left;
   display: block;
@@ -118,14 +127,6 @@ const LogoImage = styled.img`
   padding-bottom: 50px;
   width: 113px;
   height: 113px;
-`;
-
-const EditPrizeIcon = styled(FaRegEdit)`
-  color: white;
-  text-align: left;
-  display: block;
-  font-size: 45px;
-  display: inline-block;
 `;
 
 export {

--- a/frontend/src/components/navigation/navComponents.tsx
+++ b/frontend/src/components/navigation/navComponents.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { FaBars } from 'react-icons/fa';
+import { FaBars, FaRegEdit } from 'react-icons/fa';
 import { HiOutlineClipboardList } from 'react-icons/hi';
 import { GiBackwardTime } from 'react-icons/gi';
 import { MdLogout } from 'react-icons/md';
@@ -120,6 +120,14 @@ const LogoImage = styled.img`
   height: 113px;
 `;
 
+const EditPrizeIcon = styled(FaRegEdit)`
+  color: white;
+  text-align: left;
+  display: block;
+  font-size: 45px;
+  display: inline-block;
+`;
+
 export {
   BarIcon,
   ClipboardIcon,
@@ -133,4 +141,5 @@ export {
   Label,
   StyledLink,
   LogoImage,
+  EditPrizeIcon,
 };

--- a/frontend/src/components/pages/editOnePrize.tsx
+++ b/frontend/src/components/pages/editOnePrize.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import { useParams } from 'react-router-dom';
 import Header from '../navigation/header';
 import Container from './formComponents';
 import { Form, Input, Submit, Label } from '../styledComponents';
@@ -15,6 +16,7 @@ export default function EditOnePrize() {
   const [itemName, setItemName] = useState('');
   const [sponsorName, setSponsorName] = useState('');
   const [sponsorImg, setSponsorImg] = useState('');
+  const { prizeId } = useParams();
 
   const submitEdits = () => {
     console.log(itemName);
@@ -23,9 +25,9 @@ export default function EditOnePrize() {
   };
 
   return (
-    <Header headerText="Edit Prize" navbar>
+    <Header headerText="Edit Prize" back="/edit-prizes">
       <Container>
-        <StyledHours>X hours</StyledHours>
+        <StyledHours>{prizeId} hours</StyledHours>
         <div>
           <Form
             onSubmit={(e) => {

--- a/frontend/src/components/pages/editOnePrize.tsx
+++ b/frontend/src/components/pages/editOnePrize.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import Header from '../navigation/header';
+import Container from './formComponents';
+import { Form, Input, Submit, Label } from '../styledComponents';
+
+const StyledHours = styled.p`
+  font-size: 30px;
+  color: #5f8f3e;
+  font-weight: bold;
+  margin-bottom: 40px;
+`;
+
+export default function EditOnePrize() {
+  const [itemName, setItemName] = useState('');
+  const [sponsorName, setSponsorName] = useState('');
+  const [sponsorImg, setSponsorImg] = useState('');
+
+  const submitEdits = () => {
+    console.log(itemName);
+    console.log(sponsorName);
+    console.log(sponsorImg);
+  };
+
+  return (
+    <Header headerText="Edit Prize" navbar>
+      <Container>
+        <StyledHours>X hours</StyledHours>
+        <div>
+          <Form
+            onSubmit={(e) => {
+              e.preventDefault();
+              submitEdits();
+            }}
+          >
+            <Label htmlFor="itemName">Item Name</Label>
+            <Input
+              id="itemName"
+              type="text"
+              onChange={(e) => setItemName(e.target.value)}
+              placeholder="Item Name"
+              value={itemName}
+            />
+            <Label htmlFor="sponsorName">Sponsor Name</Label>
+            <Input
+              id="sponsorName"
+              type="text"
+              onChange={(e) => setSponsorName(e.target.value)}
+              placeholder="Sponsor Name"
+              value={sponsorName}
+            />
+            <Label htmlFor="sponsorImg">Sponsor Image URL</Label>
+            <Input
+              id="SponsorImg"
+              type="text"
+              onChange={(e) => setSponsorImg(e.target.value)}
+              placeholder="url"
+              value={sponsorImg}
+            />
+            <Submit type="submit" value="Save Changes" />
+          </Form>
+        </div>
+        <div />
+      </Container>
+    </Header>
+  );
+}

--- a/frontend/src/components/pages/editPrizes.tsx
+++ b/frontend/src/components/pages/editPrizes.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import { Container } from '@mui/material';
+import PrizeCard from './prizeCard';
+import Header from '../navigation/header';
+import { Prize } from '../../types';
+
+const StyledContainer = styled(Container)`
+  border-radius: 7px;
+  font-family: Poppins;
+  margin: 5px;
+  padding: 20px;
+  align-items: left;
+  justify-content: left;
+  text-decoration: none;
+`;
+
+const StyledLink = styled(Link)`
+  text-decoration: none;
+`;
+
+type PrizeProps = {
+  prizeData: Prize[];
+};
+
+export default function EditPrizes({ prizeData }: PrizeProps) {
+  return (
+    <Header headerText="Edit Prizes" navbar>
+      <StyledContainer maxWidth="md">
+        {prizeData ? (
+          prizeData.map((prize: Prize) => {
+            return (
+              <StyledLink to={`/edit-prizes/${prize._id}`} key={prize._id}>
+                <PrizeCard
+                  itemName={prize.itemName}
+                  sponsorName={prize.sponsorName}
+                  sponsorImage={prize.sponsorImage}
+                  hoursNeeded={prize.hoursNeeded}
+                />
+              </StyledLink>
+            );
+          })
+        ) : (
+          <p key="load"> Loading ...</p>
+        )}
+      </StyledContainer>
+    </Header>
+  );
+}

--- a/frontend/src/components/pages/editPrizes.tsx
+++ b/frontend/src/components/pages/editPrizes.tsx
@@ -36,7 +36,7 @@ export default function EditPrizes({ prizeData }: PrizeProps) {
                   itemName={prize.itemName}
                   sponsorName={prize.sponsorName}
                   sponsorImage={prize.sponsorImage}
-                  hoursNeeded={prize.hoursNeeded}
+                  hoursNeeded={prize._id}
                 />
               </StyledLink>
             );

--- a/frontend/src/components/pages/editPrizes.tsx
+++ b/frontend/src/components/pages/editPrizes.tsx
@@ -27,7 +27,7 @@ type PrizeProps = {
 export default function EditPrizes({ prizeData }: PrizeProps) {
   return (
     <Header headerText="Edit Prizes" navbar>
-      <StyledContainer maxWidth="md">
+      <StyledContainer maxWidth="lg">
         {prizeData ? (
           prizeData.map((prize: Prize) => {
             return (

--- a/frontend/src/components/pages/prizeCard.tsx
+++ b/frontend/src/components/pages/prizeCard.tsx
@@ -8,12 +8,16 @@ const StyledContainer = styled(Container)`
   margin-bottom: 10px;
 `;
 
-const PrizeName = styled.p`
+const PrizeName = styled.div`
   font-weight: bold;
-  font-size: 22px;
+  font-size: 18px;
+  @media screen and (min-width: 768px) {
+    padding: 0 0 15px 0;
+    font-size: 22px;
+  }
 `;
 
-const SponsorName = styled.p`
+const SponsorName = styled.div`
   font-size: 15px;
 `;
 
@@ -28,7 +32,10 @@ const LayoutDiv = styled.div`
 
 const TextDiv = styled.div`
   text-align: left;
-  padding: 10px 5px 5px 30px;
+  padding: 10px 5px 5px 10px;
+  @media screen and (min-width: 768px) {
+    padding: 10px 5px 5px 30px;
+  }
 `;
 
 const StyledDiv = styled.div`
@@ -40,20 +47,26 @@ const StyledDiv = styled.div`
 
 const HoursFlag = styled.p`
   writing-mode: vertical-rl;
+  transform: rotate(-180deg);
   background-color: #5f8f3e;
   color: white;
   font-size: 18px;
   font-weight: bold;
   margin-left: 0px;
-  border-radius: 6px 0px 0px 6px;
+  border-radius: 0px 6px 6px 0px;
   padding: 1px 10px 1px 10px;
 `;
 
 const CardImage = styled.img`
-  max-width: 100px;
+  max-width: 120px;
   max-height: 100px;
   text-align: right;
-  padding: 50px 200px 50px 10px;
+  padding: 15px 15px 15px 10px;
+  @media screen and (min-width: 768px) {
+    padding: 20px 150px 20px 10px;
+    max-width: 140px;
+    max-height: 130px;
+  }
 `;
 
 type PrizeCardProps = {

--- a/frontend/src/components/pages/prizeCard.tsx
+++ b/frontend/src/components/pages/prizeCard.tsx
@@ -1,46 +1,33 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Container } from '@mui/material';
-import { RiArrowRightSLine } from 'react-icons/ri';
 
 const StyledContainer = styled(Container)`
   background-color: #f1f1f1;
   border-radius: 6px;
-  padding: 14px;
-  padding-left: 25px;
   margin-bottom: 10px;
 `;
 
 const PrizeName = styled.p`
   font-weight: bold;
-  font-size: 20px;
-  color: black;
+  font-size: 22px;
 `;
 
 const SponsorName = styled.p`
   font-size: 15px;
-  color: black;
-`;
-
-const StyledArrow = styled(RiArrowRightSLine)`
-  color: #6c6b6b;
-  font-size: 60px;
-`;
-
-const TextDiv = styled.div`
-  text-align: left;
-  color: black;
-`;
-
-const ArrowDiv = styled.div`
-  text-align: right;
 `;
 
 const LayoutDiv = styled.div`
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  text-decoration: none;
+  flex-direction: row;
+  align-items: left;
+  color: black;
+  border-radius: 6px;
+`;
+
+const TextDiv = styled.div`
+  text-align: left;
+  padding: 5px;
 `;
 
 const StyledDiv = styled.div`
@@ -50,10 +37,16 @@ const StyledDiv = styled.div`
   }
 `;
 
-// const HoursFlag = styled.p`
-//     transform: rotate(270deg);
-//     background-color: #5F8F3E;
-// `
+const HoursFlag = styled.p`
+  writing-mode: vertical-rl;
+  background-color: #5f8f3e;
+  color: white;
+  font-size: 18px;
+  font-weight: bold;
+  margin-left: 0px;
+  border-radius: 6px 0px 0px 6px;
+  padding: 3px;
+`;
 
 type PrizeCardProps = {
   itemName: string;
@@ -68,19 +61,16 @@ export default function PrizeCard({
   sponsorImage,
   hoursNeeded,
 }: PrizeCardProps) {
+  console.log(sponsorImage);
   return (
     <StyledDiv>
-      <StyledContainer>
+      <StyledContainer disableGutters>
         <LayoutDiv>
+          <HoursFlag>{hoursNeeded} Hours</HoursFlag>
           <TextDiv>
             <PrizeName>{itemName}</PrizeName>
-            <SponsorName>{sponsorName}</SponsorName>
-            <p>{hoursNeeded}</p>
-            <p>{sponsorImage}</p>
+            <SponsorName>Sponsor: {sponsorName}</SponsorName>
           </TextDiv>
-          <ArrowDiv>
-            <StyledArrow />
-          </ArrowDiv>
         </LayoutDiv>
       </StyledContainer>
     </StyledDiv>

--- a/frontend/src/components/pages/prizeCard.tsx
+++ b/frontend/src/components/pages/prizeCard.tsx
@@ -20,14 +20,15 @@ const SponsorName = styled.p`
 const LayoutDiv = styled.div`
   display: flex;
   flex-direction: row;
-  align-items: left;
+  align-items: space-between;
+  justify-content: space-between;
   color: black;
   border-radius: 6px;
 `;
 
 const TextDiv = styled.div`
   text-align: left;
-  padding: 5px;
+  padding: 10px 5px 5px 30px;
 `;
 
 const StyledDiv = styled.div`
@@ -45,7 +46,14 @@ const HoursFlag = styled.p`
   font-weight: bold;
   margin-left: 0px;
   border-radius: 6px 0px 0px 6px;
-  padding: 3px;
+  padding: 1px 10px 1px 10px;
+`;
+
+const CardImage = styled.img`
+  max-width: 100px;
+  max-height: 100px;
+  text-align: right;
+  padding: 50px 200px 50px 10px;
 `;
 
 type PrizeCardProps = {
@@ -66,11 +74,14 @@ export default function PrizeCard({
     <StyledDiv>
       <StyledContainer disableGutters>
         <LayoutDiv>
-          <HoursFlag>{hoursNeeded} Hours</HoursFlag>
-          <TextDiv>
-            <PrizeName>{itemName}</PrizeName>
-            <SponsorName>Sponsor: {sponsorName}</SponsorName>
-          </TextDiv>
+          <LayoutDiv>
+            <HoursFlag>{hoursNeeded} Hours</HoursFlag>
+            <TextDiv>
+              <PrizeName>{itemName}</PrizeName>
+              <SponsorName>Sponsor: {sponsorName}</SponsorName>
+            </TextDiv>
+          </LayoutDiv>
+          <CardImage src={sponsorImage} alt="sponsor" />
         </LayoutDiv>
       </StyledContainer>
     </StyledDiv>

--- a/frontend/src/components/pages/prizeCard.tsx
+++ b/frontend/src/components/pages/prizeCard.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Container } from '@mui/material';
+import { RiArrowRightSLine } from 'react-icons/ri';
+
+const StyledContainer = styled(Container)`
+  background-color: #f1f1f1;
+  border-radius: 6px;
+  padding: 14px;
+  padding-left: 25px;
+  margin-bottom: 10px;
+`;
+
+const PrizeName = styled.p`
+  font-weight: bold;
+  font-size: 20px;
+  color: black;
+`;
+
+const SponsorName = styled.p`
+  font-size: 15px;
+  color: black;
+`;
+
+const StyledArrow = styled(RiArrowRightSLine)`
+  color: #6c6b6b;
+  font-size: 60px;
+`;
+
+const TextDiv = styled.div`
+  text-align: left;
+  color: black;
+`;
+
+const ArrowDiv = styled.div`
+  text-align: right;
+`;
+
+const LayoutDiv = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  text-decoration: none;
+`;
+
+const StyledDiv = styled.div`
+  text-decoration: none;
+  &:hover ${StyledContainer} {
+    background: #5f8f3e6b;
+  }
+`;
+
+// const HoursFlag = styled.p`
+//     transform: rotate(270deg);
+//     background-color: #5F8F3E;
+// `
+
+type PrizeCardProps = {
+  itemName: string;
+  sponsorName: string;
+  sponsorImage: string;
+  hoursNeeded: number;
+};
+
+export default function PrizeCard({
+  itemName,
+  sponsorName,
+  sponsorImage,
+  hoursNeeded,
+}: PrizeCardProps) {
+  return (
+    <StyledDiv>
+      <StyledContainer>
+        <LayoutDiv>
+          <TextDiv>
+            <PrizeName>{itemName}</PrizeName>
+            <SponsorName>{sponsorName}</SponsorName>
+            <p>{hoursNeeded}</p>
+            <p>{sponsorImage}</p>
+          </TextDiv>
+          <ArrowDiv>
+            <StyledArrow />
+          </ArrowDiv>
+        </LayoutDiv>
+      </StyledContainer>
+    </StyledDiv>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -27,10 +27,11 @@ interface User {
 }
 
 interface Prize {
-  _id: number;
+  _id: string;
   itemName: string;
   sponsorName: string;
   sponsorImage: string;
+  hoursNeeded: number;
 }
 
 export type { Event, Shift, User, Prize };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -27,11 +27,10 @@ interface User {
 }
 
 interface Prize {
-  _id: string;
+  _id: number;
   itemName: string;
   sponsorName: string;
   sponsorImage: string;
-  hoursNeeded: number;
 }
 
 export type { Event, Shift, User, Prize };


### PR DESCRIPTION
- Edit prizes page: list of prize cards that include the item, image, sponsor and number of hours to get the prize
- Edit A prize page: when you click on a prize card, navigates user to edit form (prize id in url params), can see info changed in console right now
- Added edit prizes to navbar
- updated prize type definition to include hours needed to get prize, I thought it made most sense to keep this info with each prize
- for whatever reason I couldn't get the green hour tags on the prize card to write with the text facing the same direction in the figma. Super weird bug but maybe you know a fix? 
- Also, didn't add any of the filtering because there's no data data associated with the prizes anywhere. If you want some sort of filtering (by hour or sponsor?) I can go back and add that.
let me know if you need any fixes!
closes #91 